### PR TITLE
Use StringIO instead of cStringIO due to character encoding issues

### DIFF
--- a/suds/sax/parser.py
+++ b/suds/sax/parser.py
@@ -36,7 +36,7 @@ from suds.sax.text import Text
 from suds.sax.attribute import Attribute
 from xml.sax import make_parser, InputSource, ContentHandler
 from xml.sax.handler import feature_external_ges
-from cStringIO import StringIO
+from StringIO import StringIO
 
 log = getLogger(__name__)
 


### PR DESCRIPTION
Unlike the memory files implemented by the StringIO module, those provided by [cStringIO] are not able to accept Unicode strings that cannot be encoded as plain ASCII strings.

From Docs: https://docs.python.org/2/library/stringio.html
